### PR TITLE
Removed the condition which gives the warning message 'Lucene filter …

### DIFF
--- a/features/org.wso2.carbon.analytics.is.feature/src/main/jaggeryapi/issessionanalytics.jag
+++ b/features/org.wso2.carbon.analytics.is.feature/src/main/jaggeryapi/issessionanalytics.jag
@@ -79,6 +79,10 @@
                 var dataPoints = JSON.parse(resp.getMessage());
                 var obj = dataPoints.categories;
 
+                if(Object.keys(obj).length == 0) {
+                    break;
+                }
+
                 var sessionIds = [];
                 var queryString = "";
                 for (var key in obj) {


### PR DESCRIPTION
…query is not given. So matching all values.'
